### PR TITLE
Added overrideMethod prop to Form component

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -1,17 +1,49 @@
 import React, {Component} from 'react'
 
+import PropTypes from 'prop-types'
 import AuthenticityToken from './AuthenticityToken'
 import classNames from 'classnames'
 
 export default class Form extends Component {
+  static propTypes = {
+    className: PropTypes.string,
+    children: PropTypes.node,
+    enableMethodOverride: PropTypes.bool,
+    methodOverrideInputName: PropTypes.string,
+    method: PropTypes.string,
+  };
+
+  static defaultProps = {
+    className:'',
+    enableMethodOverride: true,
+    methodOverrideInputName: '_method',
+    method: 'post',
+  };
+
   render() {
-    const {className, children, ...props} = this.props
+    const {
+      className,
+      children,
+      enableMethodOverride,
+      methodOverrideInputName,
+      method,
+      ...props
+    } = this.props
+
     const formClassName = classNames(className, 'rev-Form')
 
+    const overrideMethod = ( //only override the method name if its enabled and the method is not post or get.
+      enableMethodOverride &&
+      !['get','post'].includes(method.toLowerCase())
+    )
+
+    const actualMethod = overrideMethod? "post":method
+
     return (
-      <form {...props} className={formClassName}>
+      <form {...props} className={formClassName} method={actualMethod}>
         <AuthenticityToken />
-        {this.props.children}
+        {overrideMethod && (<input type="hidden" name={methodOverrideInputName} value={method} />)}
+        {children}
       </form>
     )
   }


### PR DESCRIPTION
Added a new property `enableMethodOverride` to the form component. When set to `true`, if the Form's submit method is not `get` or `post` (case-insensitive), the actual method is set to `post`, and a hidden input with the name "_method" (can be changed with the prop `methodOverrideInputName`) is added to the beginning of the forum and has its value set to the desired method.

Change suggested by Joel