### PR TITLE
Add GitHub and NPM links to docs page

### DIFF
--- a/docs-src/src/layouts/index.js
+++ b/docs-src/src/layouts/index.js
@@ -4,6 +4,7 @@ import Link from 'gatsby-link'
 import Helmet from 'react-helmet'
 import {Row, Col} from 'possum/lib/grid'
 import TopBar from 'possum/lib/TopBar'
+import Menu from 'possum/lib/Menu'
 import Navigation from './Navigation'
 
 import './index.scss'
@@ -12,6 +13,12 @@ const Header = () => (
   <TopBar fixed>
     <TopBar.Item>
       <Link to="/">Possum</Link>
+    </TopBar.Item>
+    <TopBar.Item>
+      <Menu horizontalLeft>
+        <Menu.Item><a href="https://github.com/revelrylabs/possum">GitHub</a></Menu.Item>
+        <Menu.Item><a href="https://www.npmjs.com/package/awesome-possum">NPM</a></Menu.Item>
+      </Menu>
     </TopBar.Item>
   </TopBar>
 )

--- a/docs-src/src/pages/index.js
+++ b/docs-src/src/pages/index.js
@@ -7,6 +7,7 @@ import HelpText from 'possum/lib/HelpText'
 const IndexPage = () => (
   <div>
     <h1>Possum</h1>
+
     <p>
       Possum is a framework of React components optimized for teams that want to
       ship apps fast. It is a curated list of components that work together and


### PR DESCRIPTION
In response to Issue #102, I figured that I would go ahead and add links to the GitHub and NPM page to the Header template. Currently bare-bones, but matches the minimally styled Docs page.