### PR TITLE
Removing drawer link from nav

### DIFF
--- a/docs-src/src/layouts/Navigation.js
+++ b/docs-src/src/layouts/Navigation.js
@@ -66,7 +66,6 @@ export default function Navigation() {
           <Menu.Item text><h5>Containers</h5></Menu.Item>
           <Menu.Item><Link to="/components/Accordion/">Accordion</Link></Menu.Item>
           <Menu.Item><Link to="/components/Callout/">Callout</Link></Menu.Item>
-//          <Menu.Item><Link to="/components/Drawer/">Drawer</Link></Menu.Item>
           <Menu.Item><Link to="/components/Modal/">Modal</Link></Menu.Item>
           <Menu.Item><Link to="/components/Tabs/">Tabs</Link></Menu.Item>
         </Menu>


### PR DESCRIPTION
Commenting drawer link out in Navigation didn’t work so I removed the link