### PR TITLE
Removed all inverse examples and props in components

### DIFF
--- a/docs-src/src/examples/Menu/Horizontal.js.example
+++ b/docs-src/src/examples/Menu/Horizontal.js.example
@@ -29,24 +29,4 @@
       </Menu>
     </Callout>
   </Col>
-  <Col>
-    <Callout>
-      <Menu horizontalRight inverse dividers>
-        <Menu.Item text>Right Aligned</Menu.Item>
-        <Menu.Item><a href="#">One</a></Menu.Item>
-        <Menu.Item active><a href="#">Two</a></Menu.Item>
-        <Menu.Item><a href="#">Three</a></Menu.Item>
-      </Menu>
-    </Callout>
-  </Col>
-  <Col>
-    <Callout>
-      <Menu horizontalLeft inverse icons>
-        <Menu.Item text>Left Aligned w/Icons</Menu.Item>
-        <Menu.Item><a href="#"><Icon i="home" />One</a></Menu.Item>
-        <Menu.Item><a href="#"><Icon i="home" />Two</a></Menu.Item>
-        <Menu.Item active><a href="#"><Icon i="home" />Three</a></Menu.Item>
-      </Menu>
-    </Callout>
-  </Col>
 </Row>

--- a/docs-src/src/examples/Menu/Nested.js.example
+++ b/docs-src/src/examples/Menu/Nested.js.example
@@ -39,46 +39,6 @@
       </Menu>
     </Callout>
   </Col>
-  <Col medium={6}>
-    <Callout>
-      <Menu vertical inverse>
-        <Menu.Item><a href="#">One</a>
-          <Menu nested>
-            <Menu.Item><a href="#">Nested One</a></Menu.Item>
-            <Menu.Item><a href="#">Nested Two</a></Menu.Item>
-            <Menu.Item><a href="#">Nested Three</a></Menu.Item>
-          </Menu>
-        </Menu.Item>
-        <Menu.Item><a href="#">Two</a>
-          <Menu nested vertical>
-            <Menu.Item><a href="#">Nested One</a></Menu.Item>
-            <Menu.Item><a href="#">Nested Two</a></Menu.Item>
-          </Menu>
-        </Menu.Item>
-        <Menu.Item><a href="#">Three</a></Menu.Item>
-      </Menu>
-    </Callout>
-  </Col>
-  <Col medium={6}>
-    <Callout>
-      <Menu vertical inverse dividers>
-        <Menu.Item><a href="#">One</a>
-          <Menu nested>
-            <Menu.Item><a href="#">Nested One</a></Menu.Item>
-            <Menu.Item><a href="#">Nested Two</a>
-              <Menu nested>
-                <Menu.Item><a href="#">Double Nested One</a></Menu.Item>
-                <Menu.Item><a href="#">Double Nested Two</a></Menu.Item>
-              </Menu>
-            </Menu.Item>
-            <Menu.Item><a href="#">Nested Three</a></Menu.Item>
-          </Menu>
-        </Menu.Item>
-        <Menu.Item><a href="#">Two</a></Menu.Item>
-        <Menu.Item><a href="#">Three</a></Menu.Item>
-      </Menu>
-    </Callout>
-  </Col>
   <Col>
     <Callout>
       <Menu horizontal>

--- a/docs-src/src/examples/Menu/Vertical.js.example
+++ b/docs-src/src/examples/Menu/Vertical.js.example
@@ -19,24 +19,4 @@
       </Menu>
     </Callout>
   </Col>
-  <Col medium={6} xlarge={3}>
-    <Callout>
-      <Menu verticalCentered inverse dividers>
-        <Menu.Item text>Centered</Menu.Item>
-        <Menu.Item><a href="#">One</a></Menu.Item>
-        <Menu.Item><a href="#">Two</a></Menu.Item>
-        <Menu.Item active><a href="#">Three</a></Menu.Item>
-      </Menu>
-    </Callout>
-  </Col>
-  <Col medium={6} xlarge={3}>
-    <Callout>
-      <Menu verticalRight inverse dividers icons>
-        <Menu.Item text>Right Aligned w/Icons</Menu.Item>
-        <Menu.Item><a href="#"><Icon i="home" />One</a></Menu.Item>
-        <Menu.Item><a href="#"><Icon i="home" />Two</a></Menu.Item>
-        <Menu.Item><a href="#"><Icon i="home" />Three</a></Menu.Item>
-      </Menu>
-    </Callout>
-  </Col>
 </Row>

--- a/docs-src/src/examples/Tabs/Stateful.js.example
+++ b/docs-src/src/examples/Tabs/Stateful.js.example
@@ -1,6 +1,6 @@
 <div>
   <h3>default to first tab</h3>
-  <Tabs.Stateful inverse>
+  <Tabs.Stateful>
     <Tabs.Item contentKey={1} title="One">
       <Row>
         <Col>

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -15,7 +15,6 @@ const BOOL_PROPS_TO_CLASS_NAMES = {
 
   nested: ['rev-Menu--nested'],
   dividers: ['rev-Menu--dividers'],
-  inverse: ['rev-Menu--inverse'],
   icons: ['rev-Menu--icons'],
 }
 const BOOL_PROPS = Object.keys(BOOL_PROPS_TO_CLASS_NAMES)

--- a/src/TopBar.js
+++ b/src/TopBar.js
@@ -7,7 +7,6 @@ const BOOL_PROPS_TO_CLASS_NAMES = {
   left: 'rev-TopBar--left',
   justified: 'rev-TopBar--justified',
   right: 'rev-TopBar--right',
-  inverse: 'rev-TopBar--inverse',
   breakpointMedium: 'rev-TopBar-breakpoint--mediumDown',
   breakpointLarge: 'rev-TopBar-breakpoint--largeDown',
   breakpointXlarge: 'rev-TopBar-breakpoint--xlargeDown',


### PR DESCRIPTION
- removed all inverse props from components
- removed inverse examples
* the only inverse left is the $anchor-color-inverse variable which we use in the navigation-color-mgmt mixin and probably in future components like links in a banner area*