### PR TITLE
Callout updates

### DIFF
--- a/docs-src/src/examples/Callout.js.example
+++ b/docs-src/src/examples/Callout.js.example
@@ -1,8 +1,44 @@
 <div>
-  <Callout>default</Callout>
-  <Callout primary>primary</Callout>
-  <Callout secondary>secondary</Callout>
-  <Callout success>success</Callout>
-  <Callout warning>warning</Callout>
-  <Callout alert>alert</Callout>
+  <Callout>
+    <Row>
+      <Col>
+        <p>default</p>
+      </Col>
+    </Row>
+  </Callout>
+  <Callout primary>
+    <Row>
+      <Col>
+        <p>primary</p>
+      </Col>
+    </Row>
+  </Callout>
+  <Callout secondary>
+    <Row>
+      <Col>
+        <p>secondary</p>
+      </Col>
+    </Row>
+  </Callout>
+  <Callout success>
+    <Row>
+      <Col>
+        <p>success</p>
+      </Col>
+    </Row>
+  </Callout>
+  <Callout warning>
+    <Row>
+      <Col>
+        <p>warning</p>
+      </Col>
+    </Row>
+  </Callout>
+  <Callout alert>
+    <Row>
+      <Col>
+        <p>alert</p>
+      </Col>
+    </Row>
+  </Callout>
 </div>

--- a/docs-src/src/layouts/index.js
+++ b/docs-src/src/layouts/index.js
@@ -10,20 +10,6 @@ import packageInfo from '../../../package.json'
 
 import './index.scss'
 
-const Header = () => (
-  <TopBar fixed>
-    <TopBar.Item>
-      <Link to="/">Possum</Link>
-    </TopBar.Item>
-    <TopBar.Item>
-      <Menu horizontalLeft>
-        <Menu.Item><a href="https://github.com/revelrylabs/possum">GitHub</a></Menu.Item>
-        <Menu.Item><a href="https://www.npmjs.com/package/awesome-possum">NPM</a></Menu.Item>
-      </Menu>
-    </TopBar.Item>
-  </TopBar>
-)
-
 const TemplateWrapper = ({
   children
 }) => (

--- a/docs-src/src/pages/components/Drawer.js
+++ b/docs-src/src/pages/components/Drawer.js
@@ -12,7 +12,7 @@ const examples = {
 export default class DrawerExamplePage extends Component {
   render() {
     return <div>
-      <ExampleSection title="Drawer" examples={examples} depth={1} scope={scope} />
+      <ExampleSection title="Drawers" examples={examples} depth={1} scope={scope} />
     </div>
   }
 }

--- a/scss/components/_Callout.scss
+++ b/scss/components/_Callout.scss
@@ -3,31 +3,25 @@
 // this way updates can be made to a component by uncommenting settings vars
 $callout-bkgd: $white !default;
 $callout-border-size: 1px !default;
-$callout-border-color: $divider-color !default;
+$callout-border-color: $divider-color-dark !default;
 $callout-color: $body-font-color !default;
 $callout-padding: $global-vertical-space $global-horizontal-space !default;
 
 .rev-Callout {
+  @include color-management;
   @include typography-contained;
   background: $callout-bkgd;
   border: $callout-border-size solid $callout-border-color;
   color: $callout-color;
-  margin-bottom: $global-vertical-space;
+  margin-bottom: $global-margin;
   padding: 0;
   &.rev-Callout--primary {
+    background: $callout-bkgd;
     box-shadow: $global-box-shadow;
+    color: $callout-color;
   }
   &.rev-Callout--secondary {
-    background: transparent;
-    border: 1px solid $divider-color;
-  }
-  &.rev-Callout--success {
-    background: scale-color($success, $lightness: 90%);
-  }
-  &.rev-Callout--warning {
-    background: scale-color($warning, $lightness: 90%);
-  }
-  &.rev-Callout--alert {
-    background: scale-color($alert, $lightness: 90%);
+    background: $divider-color-dark;
+    color: $callout-color;
   }
 }

--- a/scss/vars/_colors.scss
+++ b/scss/vars/_colors.scss
@@ -47,7 +47,7 @@ $warning: #D10034;
 $error: #D10034;
 
 $divider-color: $lighter-gray;
-$divider-color-dark: $black-20;
+$divider-color-dark: $black-10;
 $divider-color-light: $white-10;
 $muted: $lighter-gray;
 $very-muted: $lightest-gray;

--- a/scss/vars/_rev-settings.scss
+++ b/scss/vars/_rev-settings.scss
@@ -86,7 +86,7 @@ $grid-gutter: $grid-column-padding * 2;
 
 $global-radius: 3px;
 $global-rounded: 100000px;
-$global-box-shadow: 0 1px 4px 0 $black-40;
+$global-box-shadow: 0 1px 4px 0 $black-30;
 $global-box-shadow-hover: 0 2px 6px 0 $black-50;
 $global-box-shadow-active: 0 1px 2px 0 $black-30;
 


### PR DESCRIPTION
- updated default, primary, secondary styles
- added color mgmt mixin for util colors
- added rows/cols for padding

Some style pattern thoughts: We are used to applying a `primary` prop and seeing a component that has the $primary bkgd color. This component deviates from this in that rev-Callout--primary keeps the default callout bkgd color (set in rev-settings) and only adds a dropshadow.
I think in this case it is an acceptable style deviation because 
1. I personally never need a primary-colored callout
2. if you look at the button component as a comparison, .rev-Button--primary is only adding a dropshadow and maintains the default button color (although the default button color *is* $primary).
3. I would like to further separate primary and secondary classes/props from meaning color. I would like primary to mean 'important' and secondary to mean 'less important', regardless of color.
**3a.** As a small step towards making this happen, I have changed the `$primary` color var to `$brand` since I would like colors to be tied to branding vs. importance. Although there *is* still a `$primary` color var which by default is set to `$brand`. A little ass-backwards but my hope is that you can change your $primary color to be whatever means 'important' to you, and you can still maintain your brand colors.

![screen shot 2018-02-08 at 12 11 38 pm](https://user-images.githubusercontent.com/3287583/35990378-73cdec80-0cc9-11e8-8ac7-490eb85022e0.png)
