### PR TITLE
[CardLayout css modified for image space issue in IE11]

### DIFF
--- a/scss/components/_CardLayout.scss
+++ b/scss/components/_CardLayout.scss
@@ -3,6 +3,7 @@
 }
 .rev-CardLayout-bar {
   flex: 0 1 auto;
+  min-height: 1px;
 }
 .rev-CardLayout-fill {
   flex: 1 1 auto;


### PR DESCRIPTION
#118 

- [x] Remove extra empty space under the image in card layout (the card with the padding around the image) for IE 11
- [x] Remove empty space under the image in the card with no padding around the image for IE 11

The issue has been mentioned below (and in many other posts). This issue is closed.
1. IE11 image resizing bug using Cards and Flexbox #10079
[https://github.com/zurb/foundation-sites/issues/10079](url)

Below is a IE11 screenshot.
![cardr](https://user-images.githubusercontent.com/15636958/37159979-c68f7d52-22b4-11e8-8234-b77e1a31db76.PNG)








 