### PR TITLE
Date picker firefox

### DIFF
--- a/scss/components/_DatePicker.scss
+++ b/scss/components/_DatePicker.scss
@@ -12,6 +12,22 @@ $calendar-header-height: $size-large !default;
 .rev-DatePicker {
   display: block;
   position: relative;
+/*   this enables the Chrome and Firefox designs to be the same
+ */    
+    ::-moz-placeholder {
+      opacity: 1;
+      color: black;
+    }
+
+    ::-webkit-input-placeholder {
+      opacity: 1;
+      color: black;
+    }
+
+    :-ms-input-placeholder {
+      opacity: 1;
+      color: black;
+    }
 }
 .rev-Calendar {
   @include global-transition;

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -24,6 +24,17 @@ function goodDateInput() {
   }
 }
 
+/**
+ * Return true if Firefox browser
+ * Date type inputs are supported on Firefox but not possible to 
+ * prevent the native calendar popup dialog, resulting in two calendars
+ * showing. Need to default to type text input.
+ * @return {boolean} true is date type inputs are well supported, false otherwise
+ */
+const isFirefox = () => {
+  return /Firefox/i.test(navigator.userAgent);
+}
+
 /** A DatePicker component containing inputs and a calendar. */
 class UncontrolledDatePicker extends React.Component {
   /**
@@ -48,7 +59,7 @@ class UncontrolledDatePicker extends React.Component {
     super(props)
     // On platforms with poor date input support, or when non-standard format is
     // specified, we have to fall back to a text type input
-    this.goodDateInput = goodDateInput() && !this.props.dateFormat
+    this.goodDateInput = goodDateInput() && !this.props.dateFormat && !isFirefox()
     this.state = {
       isOpen: this.props.isOpen || false,
       focused: false,

--- a/src/DatePicker/DateInputBlock.js
+++ b/src/DatePicker/DateInputBlock.js
@@ -44,6 +44,8 @@ const DateInputBlock = ({
         type={goodDateInput ? 'date' : 'text'}
         name={goodDateInput ? name : null}
         defaultValue={formattedValue}
+/*         have a placeholder to avoid empty box on Firefox  */
+        placeholder={dateFormat ? dateFormat : 'mm/dd/yyyy'}
       />
       {goodDateInput ? null : (
         <Input


### PR DESCRIPTION
Hello,
#140 
I haven’t found a way to hide the Firefox native date picker calendar. 
[htps://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#Pseudo-elements_and_pseudo-classes](url)
It seems there isn’t a ::-webkit-calendar-picker-indicator equivalent in Mozilla.

The Firefox calendar shows up on click (with the Chrome version, the calendar appears on clicking on the drop-down calendar arrow). Preventing default behavior onClick seems to be the only way to hide the Firefox calendar popup. 
