### PR TITLE
#158 possible solution, replace prepublishOnly with prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "docs": "node scripts/docs.js",
     "web": "static-server docs -p $PORT",
     "dev": "gulp",
-    "prepublishOnly": "npm run clean && npm run babel"
+    "prepublish": "npm run clean && npm run babel"
   },
   "keywords": [],
   "author": {


### PR DESCRIPTION
Would adding 
`"prepublish": "npm run clean && npm run babel"`
instead of "prepublishOnly" be a good solution? 