### PR TITLE
updated readme to show awesome-possum instead of possum

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ npm install --save awesome-possum
 You can import components and use components from the toolkit like:
 
 ```jsx
-import Col from 'possum/lib/Col'
-import Row from 'possum/lib/Row'
-import Callout from 'possum/lib/Callout'
+import Col from 'awesome-possum/lib/Col'
+import Row from 'awesome-possum/lib/Row'
+import Callout from 'awesome-possum/lib/Callout'
 
 function Hello() {
   return (


### PR DESCRIPTION
Hey Robert. Was using awesome possum on a Scandy project this weekend and the readme example didn't work for me unless I used 'awesome-possum' as the package name. Forgive the wordy pull request details - I'm quite sure you could have figured this out. Would appreciate any feedback you might offer on this.