### PR TITLE
[reverse min-height for images and IE11]

### DIFF
--- a/scss/components/_CardLayout.scss
+++ b/scss/components/_CardLayout.scss
@@ -3,7 +3,6 @@
 }
 .rev-CardLayout-bar {
   flex: 0 1 auto;
-  min-height: 1px;
 }
 .rev-CardLayout-fill {
   flex: 1 1 auto;


### PR DESCRIPTION
#176 
@prehnRA I apologize I only saw the open issue tonight, this is due to a change of mine to fix the extra space there is with images in IE11. I will look for a solution on the extra space issue in IE 11.
