### PR TITLE
Allow click to the right of calendar to close (#189)

### DIFF
--- a/scss/components/_DatePicker.scss
+++ b/scss/components/_DatePicker.scss
@@ -12,8 +12,10 @@ $calendar-header-height: $size-large !default;
 .rev-DatePicker {
   display: block;
   position: relative;
+  width: $calendar-container-width;
+
 /*   this enables the Chrome and Firefox designs to be the same
- */    
+ */
     ::-moz-placeholder {
       opacity: 1;
       color: black;


### PR DESCRIPTION
#189 Close calendar when clicking to the right of the calendar component
Connect to #189 
* Closes calendar as expected. However, it did shorten the length of the date input block.
  
Cannot click right
<img width="1036" alt="cannot-click-right" src="https://user-images.githubusercontent.com/10157307/38935527-8bf6ff50-42ec-11e8-80aa-35e7418abfb7.png">

Can click right
<img width="354" alt="click-right" src="https://user-images.githubusercontent.com/10157307/38935567-a70177da-42ec-11e8-9530-0f3291f33daf.png">


