### PR TITLE
Lint Datepicker components

### DIFF
--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -33,6 +33,8 @@ function goodDateInput() {
  * showing. Need to default to type text input.
  * @return {boolean} true is date type inputs are well supported, false otherwise
  */
+
+/* prettier-ignore */
 const isFirefox = () => {
   return (/Firefox/i).test(navigator.userAgent)
 }
@@ -53,8 +55,9 @@ class UncontrolledDatePicker extends React.Component {
    * Create a datepicker. Determines if we can use browser native date type input
    * or if we need to fall back to a text type input (based on support and if a
    * non-standard format is specified.)
-   * @param {object} props
+   * @param {object} props - the props
    */
+  /* eslint complexity: [2, 4] */
   constructor(props) {
     super(props)
     // On platforms with poor date input support, or when non-standard format is
@@ -80,7 +83,8 @@ class UncontrolledDatePicker extends React.Component {
    * Handle updated props from up the chain. In particular, if we receive a new
    * date from up the hierarchy, we want to reset the inputs and the calendar to
    * that value.
-   * @param {object} nextProps
+   * @param {object} nextProps - the next props
+   * @return {void}
    */
   componentWillReceiveProps(nextProps) {
     this.setState(this.valuesFromProps(nextProps))
@@ -90,7 +94,7 @@ class UncontrolledDatePicker extends React.Component {
    * Find the date value from the props, and convert it to two values-- an iso
    * date and a 'local' format date version (so we can deal with poorly formatted
    * text inputs intelligently).
-   * @param {object} props
+   * @param {object} props - the props
    * @return {object} an object with two keys: isoValue & formattedValue
    */
   valuesFromProps(props) {
@@ -126,6 +130,7 @@ class UncontrolledDatePicker extends React.Component {
    * Process change events from the input by updating the isoValue & formattedValue
    * of this component. Will call down to an onChange handler passed in.
    * @param {Event} event - the change event fired from the input
+   * @return {void}
    */
   onChange(event) {
     // Take whatever format the input gave us, and turn it into an ISO date string
@@ -153,15 +158,17 @@ class UncontrolledDatePicker extends React.Component {
   get dateFormat() {
     // TODO: detect locale default format string and use that instead of
     //   hardcoded 'MM/dd/yyyy'
-    return this.goodDateInput ?
-      'yyyy-MM-dd' :
-      this.props.dateFormat || 'MM/dd/yyyy'
+    /* eslint-disable operator-linebreak */
+    return this.goodDateInput
+      ? 'yyyy-MM-dd'
+      : this.props.dateFormat || 'MM/dd/yyyy'
   }
 
   /**
    * Invoked by the calendar to tell the date picker to update the inputs (onClick
    * of the calendar buttons).
    * @param {string} date - the new date, in the format yyyy-MM-dd
+   * @return {void}
    */
   dateChanger(date) {
     // Update isoValue & formattedValue based on the date value (which is an iso
@@ -186,6 +193,7 @@ class UncontrolledDatePicker extends React.Component {
    * Create a synthetic change event and send it into the change handlers as if
    * the user had typed the new value. This makes typed input and calendar button
    * clicks fire off the same handlers.
+   * @return {void}
    */
   fireChangeHandler() {
     const event = new Event('change')
@@ -204,6 +212,7 @@ class UncontrolledDatePicker extends React.Component {
   useNativePicker() {
     return (
       typeof navigator !== 'undefined' &&
+      /* prettier-ignore */
       (/Android|iPhone|iPad|iPod/i).test(navigator.userAgent)
     )
   }
@@ -212,6 +221,7 @@ class UncontrolledDatePicker extends React.Component {
    * Track when the mouse cursor is over the component, so that we can not
    * immediately close the calendar when we lose focus-- which happens if you
    * click the calendar buttons.
+   * @return {void}
    */
   mouseIn() {
     this.setState({mousedIn: true})
@@ -221,6 +231,7 @@ class UncontrolledDatePicker extends React.Component {
    * Track when the mouse is no longer over the component, which means that it
    * is safe to close the calendar if we lose focus, for example, because the
    * focus has moved to the next element.
+   * @return {void}
    */
   mouseOut() {
     this.setState({mousedIn: false, isOpen: this.state.focused})
@@ -230,6 +241,8 @@ class UncontrolledDatePicker extends React.Component {
    * Mark the input as in focus. Used to determine whether the calendar should
    * be open or not.
    * @param {Event} event - the focus event
+   * @return {void}
+   *
    */
   focus(event) {
     if (this.props.onFocus) {
@@ -242,6 +255,7 @@ class UncontrolledDatePicker extends React.Component {
    * Mark the input as out of focus. Used to determine whether the calendar should
    * be open or not.
    * @param {Event} event - the focus event
+   * @return {void}
    */
   blur(event) {
     if (this.props.onBlur) {
@@ -253,6 +267,7 @@ class UncontrolledDatePicker extends React.Component {
   /**
    * Force the input back into focus. Used when calendar buttons are clicked, so
    * that the input stays in focus and we don't close the calendar.
+   * @return {void}
    */
   refocus() {
     if (this.nativeInput) {
@@ -271,6 +286,7 @@ class UncontrolledDatePicker extends React.Component {
    *   input)
    * @returns {boolean} - true if the calendar should be open
    */
+  /* eslint complexity: [2, 5] */
   get calendarOpened() {
     return (
       (this.state.isOpen || this.props.isOpen) &&
@@ -295,9 +311,9 @@ class UncontrolledDatePicker extends React.Component {
       ...props
     } = this.props
     const createElement = createElementWithOverride.bind(this, overrides)
-    const nativeClass = this.useNativePicker() ?
-      'rev-DatePicker--native' :
-      'rev-DatePicker--custom'
+    const nativeClass = this.useNativePicker()
+      ? 'rev-DatePicker--native'
+      : 'rev-DatePicker--custom'
     const inputId = uniqueId('DateInputBlock:')
     const dateInputBlockProps = omit(props, 'isOpen')
 

--- a/src/DatePicker/CalendarDay.js
+++ b/src/DatePicker/CalendarDay.js
@@ -24,7 +24,10 @@ function calculateMonthClass(date, currentMonth) {
  *   selectable
  * @param {DateTime} date - a Luxon DateTime for the date in question
  * @param {string} selectedDate - an iso string of the selected date
+ * @return {string} - a class to use for styling
  */
+
+/* eslint complexity: [2, 4] */
 function calculateSelectionClass(isSelectable, date, selectedDate) {
   const selectable = isSelectable(date)
 
@@ -43,6 +46,7 @@ function calculateSelectionClass(isSelectable, date, selectedDate) {
  * @param {object|Array|Function} highlights a mapping between dates and
  *   highlight classes. If an array, gives a standard --highlighted modifier to
  *   a found date cell.
+ * @return {string} - a class to use for styling
  */
 function calculateHighlightClass(date, highlights) {
   return (
@@ -62,6 +66,8 @@ function calculateHighlightClass(date, highlights) {
  * @param {Function} isSelectable returns true if the date is selectable
  * @param {DateTime} date the date in question
  * @param {Function} dateChanger the handler to invoke if the cell is selectable
+ * @return {(Function| null)} - if the cell is selectable, invoke the
+ * dateChanger that was passed in. If not, do nothing
  */
 function dayClickHandler(isSelectable, date, dateChanger) {
   const selectable = isSelectable(date)

--- a/src/DatePicker/DateInputBlock.js
+++ b/src/DatePicker/DateInputBlock.js
@@ -31,6 +31,7 @@ class DateInputBlock extends Component {
     className: PropTypes.string,
   }
 
+  /* eslint-disable-next-line complexity */
   render() {
     const {
       error,


### PR DESCRIPTION
There are two conflicting rules between eslint and prettier
 * eslint's ```"wrap-regex": 2``` does not adhere to prettier's styling
 * eslint's ```"operator-linebreak": [ 2,"after" ]``` does not adhere to prettier's styling

In both cases, I chose the rule I preferred but perhaps it's best to always default to prettier in such cases.

Also ```"complexity": [2, 3]``` seems to be tough to follow.