### PR TITLE
Row col updates

### DIFF
--- a/docs-src/src/examples/grid/HorizontalAlignmentOnRow.js.example
+++ b/docs-src/src/examples/grid/HorizontalAlignmentOnRow.js.example
@@ -1,21 +1,21 @@
 <div className="ColumnExamples">
-  <Row flex left>
+  <Row flex justifyStart>
     <Col small={4}>Aligned to</Col>
     <Col small={4}>the left</Col>
   </Row>
-  <Row flex right>
+  <Row flex justifyEnd>
     <Col small={4}>Aligned to</Col>
     <Col small={4}>the right</Col>
   </Row>
-  <Row flex center>
+  <Row flex justifyCenter>
     <Col small={4}>Aligned to</Col>
     <Col small={4}>the middle</Col>
   </Row>
-  <Row flex justify>
+  <Row flex justifySpaceBetween>
     <Col small={4}>Aligned to</Col>
     <Col small={4}>the edges</Col>
   </Row>
-  <Row flex spaced>
+  <Row flex justifySpaceAround>
     <Col small={4}>Aligned to</Col>
     <Col small={4}>the space around</Col>
   </Row>

--- a/docs-src/src/examples/grid/VerticalAlignmentOnCol.js.example
+++ b/docs-src/src/examples/grid/VerticalAlignmentOnCol.js.example
@@ -1,20 +1,30 @@
 <div>
   <Row flex className="ColumnExamples">
-    <Col bottom small={6}>Align bottom</Col>
+    <Col alignStart small={6}>Align-self start</Col>
     <Col small={6}>
       <Lipsum />
     </Col>
   </Row>
-
   <Row flex className="ColumnExamples">
-    <Col middle small={6}>Align middle</Col>
+    <Col alignEnd small={6}>Align-self end</Col>
     <Col small={6}>
       <Lipsum />
     </Col>
   </Row>
-
   <Row flex className="ColumnExamples">
-    <Col top small={6}>Align top</Col>
+    <Col alignCenter small={6}>Align-self center</Col>
+    <Col small={6}>
+      <Lipsum />
+    </Col>
+  </Row>
+  <Row flex className="ColumnExamples">
+    <Col alignStretch small={6}>Align-self stretch</Col>
+    <Col small={6}>
+      <Lipsum />
+    </Col>
+  </Row>
+  <Row flex className="ColumnExamples">
+    <Col alignBaseline small={6}>Align-self baseline</Col>
     <Col small={6}>
       <Lipsum />
     </Col>

--- a/docs-src/src/examples/grid/VerticalAlignmentOnRow.js.example
+++ b/docs-src/src/examples/grid/VerticalAlignmentOnRow.js.example
@@ -1,24 +1,36 @@
 <div className="ColumnExamples">
-  <Row middle flex>
-    <Col small={6}>I&apos;m in the middle!</Col>
+  <Row alignStart flex>
+    <Col small={6}>Columns aligned flex-start</Col>
     <Col small={6}>
       <Lipsum />
     </Col>
   </Row>
-  <Row top flex>
-    <Col small={6}>These columns align to the top.</Col>
+  <Row alignEnd flex>
+    <Col small={6}>Columns aligned flex-end</Col>
     <Col small={6}>
       <Lipsum />
     </Col>
   </Row>
-  <Row bottom flex>
-    <Col small={6}>bottom</Col>
+  <Row alignCenter flex>
+    <Col small={6}>Columns aligned center</Col>
+    <Col small={6}>
+      <Lipsum />
+    </Col>
+  </Row>
+  <Row alignStretch flex>
+    <Col small={6}>Columns aligned stretch</Col>
+    <Col small={6}>
+      <Lipsum />
+    </Col>
+  </Row>
+  <Row alignBaseline flex>
+    <Col small={6}><h4>Columns aligned baseline</h4></Col>
     <Col small={6}>
       <Lipsum />
     </Col>
   </Row>
   <Row flex>
-    <Col small={6}>unspecified simply fills all vertical space</Col>
+    <Col small={6}>Unspecified columns fill vertical space</Col>
     <Col small={6}>
       <Lipsum />
     </Col>

--- a/docs-src/src/layouts/index.scss
+++ b/docs-src/src/layouts/index.scss
@@ -63,56 +63,57 @@ h5, h6 {
 .ColumnExamples {
   &.rev-Row,
   .rev-Row {
-    margin-bottom: $global-vertical-space;
+    margin-bottom: $global-margin;
     .rev-Row {
       margin-bottom: 0;
     }
   }
   .rev-Col {
+    // bottom and top padding for demo purposes only
+    padding-bottom: $global-padding;
+    padding-top: $global-padding;
     text-align: center;
-    background-clip: content-box;
-    position: relative;
     // All of this is a way to put an outline-esque border on the left and
     // right edge without taking up space (doing it this way, because outline
     // can't be applied to only left and right).
     // If we just put left and right borders, it can cause weird overflows
     // and wrapping with the grid, which is bad for a grid demo page
     &:before {
-      // Needs content to be placed in DOM
-      content: ' ';
+      // Mark left and right edges
+      border-left: 2px dotted $gray;
+      border-right: 2px dotted $gray;
       // Position to be the same size and location as the column
       bottom: 0;
-      left: 0;
+      // Needs content to be placed in DOM
+      content: ' ';
+      left: -1px;
       position: absolute;
-      right: 0;
+      right: -1px;
       top: 0;
-      // Mark left and right edges
-      border-left: 1px dashed $gray;
-      border-right: 1px dashed $gray;
     }
   }
   // Throw some grayscale colors on the grid columns to show what space they
   // occupy
-  .columns:nth-child(6n + 1) {
-    @include color-stack($gray);
+  .rev-Col:nth-child(6n + 1) {
+    @include color-stack($lightest-gray);
   }
-  .columns:nth-child(6n + 2) {
-    @include color-stack($black);
-  }
-  .columns:nth-child(6n + 3) {
-    @include color-stack($darker-gray);
-  }
-  .columns:nth-child(6n + 4) {
-    @include color-stack($dark-gray);
-  }
-  .columns:nth-child(6n + 5) {
-    @include color-stack($light-gray);
-  }
-  .columns:nth-child(6n + 6) {
+  .rev-Col:nth-child(6n + 2) {
     @include color-stack($lighter-gray);
   }
+  .rev-Col:nth-child(6n + 3) {
+    @include color-stack($light-gray);
+  }
+  .rev-Col:nth-child(6n + 4) {
+    @include color-stack($gray);
+  }
+  .rev-Col:nth-child(6n + 5) {
+    @include color-stack($dark-gray);
+  }
+  .rev-Col:nth-child(6n + 6) {
+    @include color-stack($darker-gray);
+  }
   // For nesting example, show the extents of the nested row
-  .columns .row {
+  .rev-Col .rev-Row {
     outline: 1px solid $white;
   }
   // removing the bkgd on Block Grid so that kitty images look better

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "awesome-possum",
+  "name": "harmonium",
   "version": "3.5.3",
   "description": "An opinionated React component framework for teams that move fast.",
   "repository": {
@@ -73,11 +73,12 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-prettier": "^2.5.0",
     "eslint-plugin-react": "^7.7.0",
+    "graceful-readlink": "^1.0.1",
     "gulp": "^3.9.1",
     "gulp-webserver": "^0.9.1",
     "jsdom": "^11.0.0",
     "jsdom-global": "^3.0.2",
-    "mocha": "^3.4.2",
+    "mocha": "^3.5.3",
     "nyc": "^11.4.1",
     "prettier": "^1.11.1",
     "prettier-eslint": "^8.8.1",

--- a/scss/components/_FlexCols.scss
+++ b/scss/components/_FlexCols.scss
@@ -1,53 +1,24 @@
-// Justify Content
-.rev-Row--end {
-  @include flexJustifyEnd;
-}
-.rev-Row--center {
-  @include flexJustifyCenter;
-}
-.rev-Row--spaced,
-.rev-Row--spaceAround {
-  @include flexJustifySpaceAround;
-}
-.rev-Row--justify,
-.rev-Row--spaceBetween {
-  @include flexJustifySpaceBetween;
-}
-// Align Items
-.rev-Row--top {
-  @include flexAlignStart;
-}
-.rev-Row--middle {
-  @include flexAlignCenter;
-}
-.rev-Row--bottom {
-  @include flexAlignEnd;
-}
-.rev-Row--stretch {
-  @include flexAlignStretch;
-}
-.rev-Row--baseline {
-  @include flexAlignBaseline;
-}
 // Align Self
-.rev-Col {
+.rev-Row--flex .rev-Col {
+  flex-grow: 1;
+  flex-shrink: 0;
   &.rev-Col--shrink {
     flex: 0 0 auto;
     width: auto;
   }
-  &.rev-Col--end {
-    align-self: flex-end;
-  }
-  &.rev-Col--center {
-    align-self: center;
-  }
-  &.rev-Col--start {
+  &.rev-Col--alignStart {
     align-self: flex-start;
   }
-  &.rev-Col--baseline {
+  &.rev-Col--alignEnd {
+    align-self: flex-end;
+  }
+  &.rev-Col--alignCenter {
+    align-self: center;
+  }
+  &.rev-Col--alignBaseline {
     align-self: baseline;
   }
-  &.rev-Col--stretch {
+  &.rev-Col--alignStretch {
     align-self: stretch;
   }
 }

--- a/scss/components/_FlexRows.scss
+++ b/scss/components/_FlexRows.scss
@@ -1,0 +1,88 @@
+// Flex ROWS
+.rev-Row--flex,
+.rev-Row--smallFlex, {
+  display: flex;
+  flex-flow: row wrap;
+  &:before,
+  &:after {
+    content: none;
+  }
+  .rev-Col {
+    flex: 1 1 0px;
+  }
+  .shrink {
+    flex: 0 0 auto;
+  }
+}
+.rev-Row--unflex,
+.rev-Row--smallUnflex {
+  display: block;
+}
+@include breakpoint(medium) {
+  .rev-Row--mediumFlex {
+    display: flex;
+  }
+  .rev-Row--mediumUnflex {
+    display: block;
+  }
+}
+@inclue breakpoint(large) {
+  .rev-Row--largeFlex {
+    display: flex;
+  }
+  .rev-Row--largeUnflex {
+    display: block;
+  }
+}
+@include breakpoint(xlarge) {
+  .rev-Row--xlargeFlex {
+    display: flex;
+  }
+  .rev-Row--xlargeUnflex {
+    display: block;
+  }
+}
+@inlcude breakpoint(xxlarge){
+  .rev-Row--xxlargeFlex {
+    display: flex;
+  }
+  .rev-Row--xxlargeUnflex {
+    display: block;
+  }
+}
+// Direction Col
+.rev-Row--directionCol {
+  @include flexDirectionCol;
+}
+// Justify Content
+.rev-Row--justifyStart {
+  @include flexJustifyStart;
+}
+.rev-Row--justifyEnd {
+  @include flexJustifyEnd;
+}
+.rev-Row--justifyCenter {
+  @include flexJustifyCenter;
+}
+.rev-Row--justifySpaceAround {
+  @include flexJustifySpaceAround;
+}
+.rev-Row--justifySpaceBetween {
+  @include flexJustifySpaceBetween;
+}
+// Align Items
+.rev-Row--alignStart {
+  @include flexAlignStart;
+}
+.rev-Row--alignEnd {
+  @include flexAlignEnd;
+}
+.rev-Row--alignCenter {
+  @include flexAlignCenter;
+}
+.rev-Row--alignStretch {
+  @include flexAlignStretch;
+}
+.rev-Row--alignBaseline {
+  @include flexAlignBaseline;
+}

--- a/scss/components/_FloatCols.scss
+++ b/scss/components/_FloatCols.scss
@@ -1,0 +1,115 @@
+// COLUMNS
+.rev-Col {
+  float: left;
+  padding: 0 $grid-column-padding;
+  position: relative;
+  width: 100%;
+  &.rev-Col--centered,
+  &.rev-Col--smallCentered {
+    float: none;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  &.rev-Col--Uncentered,
+  &.rev-Col--smallUncentered {
+    float: left;
+  }
+  &.rev-Col--end {
+    float: right;
+  }
+  @for $i from 1 through $grid-columns {
+    &.rev-Col--smallOffset#{$i} {
+      left: 100% / $grid-columns * $i;
+    }
+    &.rev-Col--smallPush#{$i} {
+      @include rev-Col-push($i);
+    }
+    &.rev-Col--smallPull#{$i} {
+      @include rev-Col-pull($i);
+    }
+  }
+  @include breakpoint(medium) {
+    @for $i from 1 through $grid-columns {
+      &.rev-Col--mediumOffset#{$i} {
+        left: 100% / $grid-columns * $i;
+      }
+      &.rev-Col--mediumPush#{$i} {
+        @include rev-Col-push($i);
+      }
+      &.rev-Col--mediumPull#{$i} {
+        @include rev-Col-pull($i);
+      }
+    }
+    .rev-Col--mediumCentered {
+      float: none;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    .rev-Col--mediumUncentered {
+      float: left;
+    }
+  }
+  @include breakpoint(large) {
+    @for $i from 1 through $grid-columns {
+      &.rev-Col--largeOffset#{$i} {
+        left: 100% / $grid-columns * $i;
+      }
+      &.rev-Col--largePush#{$i} {
+        @include rev-Col-push($i);
+      }
+      &.rev-Col--largePull#{$i} {
+        @include rev-Col-pull($i);
+      }
+    }
+    &.rev-Col--largeCentered {
+      float: none;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    &.rev-Col--largeUncentered {
+      float: left;
+    }
+  }
+  @include breakpoint(xlarge) {
+    @for $i from 1 through $grid-columns {
+      &.rev-Col--xlargeOffset#{$i} {
+        left: 100% / $grid-columns * $i;
+      }
+      &.rev-Col--xlargePush#{$i} {
+        @include rev-Col-push($i);
+      }
+      &.rev-Col--xlargePull#{$i} {
+        @include rev-Col-pull($i);
+      }
+    }
+    &.rev-Col--xlargeCentered {
+      float: none;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    &.rev-Col--xlargeUncentered {
+      float: left;
+    }
+  }
+  @include breakpoint(xxlarge) {
+    @for $i from 1 through $grid-columns {
+      &.rev-Col--xxlargeOffset#{$i} {
+        left: 100% / $grid-columns * $i;
+      }
+      &.rev-Col--xxlargePush#{$i} {
+        @include rev-Col-push($i);
+      }
+      &.rev-Col--xxlargePull#{$i} {
+        @include rev-Col-pull($i);
+      }
+    }
+    &.rev-Col--xxlargeCentered {
+      float: none;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    &.rev-Col--xxlargeUncentered {
+      float: left;
+    }
+  }
+}

--- a/scss/components/_Grid.scss
+++ b/scss/components/_Grid.scss
@@ -1,4 +1,4 @@
-// ROWS
+// ROWS (float and flex)
 .rev-Row {
   display: block;
   margin-left: 0;
@@ -12,21 +12,7 @@
     clear: both;
     display: table;
   }
-  &.rev-Row--flex,
-  &.rev-Row--smallFlex, {
-    display: flex;
-    flex-flow: row wrap;
-    .rev-Col {
-      flex: 1 1 0px;
-    }
-    .shrink {
-      flex: 0 0 auto;
-    }
-  }
-  &.rev-Row--unflex,
-  &.rev-Row--smallUnflex {
-    display: block;
-  }
+  // Collapse padding on direct child cols
   &.rev-Row--collapse,
   &.rev-Row--smallCollapse {
     > .rev-Col {
@@ -34,6 +20,7 @@
       padding-right: 0;
     }
   }
+  // Reset padding on direct child cols
   &.rev-Row--uncollapse,
   &.rev-Row--smallUncollapse {
     > .rev-Col {
@@ -41,16 +28,7 @@
       padding-right: $grid-column-padding;
     }
   }
-  &.rev-Row--right {
-    justify-content: flex-end;
-  }
   @include breakpoint(medium)  {
-    &.rev-Row--mediumFlex {
-      display: flex;
-    }
-    &.rev-Row--mediumUnflex {
-      display: block;
-    }
     &.rev-Row--mediumCollapse {
       > .rev-Col {
         padding-left: 0;
@@ -65,12 +43,6 @@
     }
   }
   @include breakpoint(large)  {
-    &.rev-Row--largeFlex {
-      display: flex;
-    }
-    &.rev-Row--largeUnflex {
-      display: block;
-    }
     &.rev-Row--largeCollapse {
       > .rev-Col {
         padding-left: 0;
@@ -85,12 +57,6 @@
     }
   }
   @include breakpoint(xlarge)  {
-    &.rev-Row--xlargeFlex {
-      display: flex;
-    }
-    &.rev-Row--xlargeUnflex {
-      display: block;
-    }
     &.rev-Row--xlargeCollapse {
       > .rev-Col {
         padding-left: 0;
@@ -105,12 +71,6 @@
     }
   }
   @include breakpoint(xxlarge)  {
-    &.rev-Row--xxlargeFlex {
-      display: flex;
-    }
-    &.rev-Row--xxlargeUnflex {
-      display: block;
-    }
     &.rev-Row--xxlargeCollapse {
       > .rev-Col {
         padding-left: 0;
@@ -126,25 +86,31 @@
   }
 }
 
-// COLUMNS
+// COLUMNS (float and flex)
 .rev-Col {
-  flex-grow: 1;
-  flex-shrink: 0;
-  float: left;
   padding: 0 $grid-column-padding;
   position: relative;
   width: 100%;
-  &.rev-Col--end {
-    float: right;
-  }
+  // Collapse padding on cols
   &.rev-Col--collapse {
     padding-left: 0;
     padding-right: 0;
   }
+  // Reset padding on cols
   &.rev-Col--uncollapse {
     padding: 0 $grid-column-padding;
   }
+  @for $i from 1 through $grid-columns {
+    &.rev-Col--small#{$i} {
+      width: 100% / $grid-columns * $i;
+    }
+  }
   @include breakpoint(medium) {
+    @for $i from 1 through $grid-columns {
+      &.rev-Col--medium#{$i} {
+        width: 100% / $grid-columns * $i;
+      }
+    }
     &.rev-Col--mediumCollapse {
       padding-left: 0;
       padding-right: 0;
@@ -154,6 +120,11 @@
     }
   }
   @include breakpoint(large) {
+    @for $i from 1 through $grid-columns {
+      &.rev-Col--large#{$i} {
+        width: 100% / $grid-columns * $i;
+      }
+    }
     &.rev-Col--largeCollapse {
       padding-left: 0;
       padding-right: 0;
@@ -163,6 +134,11 @@
     }
   }
   @include breakpoint(xlarge) {
+    @for $i from 1 through $grid-columns {
+      &.rev-Col--xlarge#{$i} {
+        width: 100% / $grid-columns * $i;
+      }
+    }
     &.rev-Col--xlargeCollapse {
       padding-left: 0;
       padding-right: 0;
@@ -172,6 +148,11 @@
     }
   }
   @include breakpoint(xxlarge) {
+    @for $i from 1 through $grid-columns {
+      &.rev-Col--xxlarge#{$i} {
+        width: 100% / $grid-columns * $i;
+      }
+    }
     &.rev-Col--xxlargeCollapse {
       padding-left: 0;
       padding-right: 0;
@@ -179,135 +160,5 @@
     &.rev-Col--xxlargeUncollapse {
       padding: 0 $grid-column-padding;
     }
-  }
-}
-.rev-Col--centered,
-.rev-Col--smallCentered {
-  float: none;
-  margin-left: auto;
-  margin-right: auto;
-}
-.rev-Col--Uncentered,
-.rev-Col--smallUncentered {
-  float: left;
-}
-.rev-Col--bottom {
-  align-self: flex-end;
-}
-.rev-Col--middle {
-  align-self: center;
-}
-.rev-Col--top {
-  align-self: flex-start;
-}
-
-@for $i from 1 through $grid-columns {
-  .rev-Col--small#{$i} {
-    width: 100% / $grid-columns * $i;
-  }
-  .rev-Col--smallOffset#{$i} {
-    left: 100% / $grid-columns * $i;
-  }
-  .rev-Col--smallPush#{$i} {
-    @include rev-Col-push($i);
-  }
-  .rev-Col--smallPull#{$i} {
-    @include rev-Col-pull($i);
-  }
-}
-@include breakpoint(medium)  {
-  @for $i from 1 through $grid-columns {
-    .rev-Col--medium#{$i} {
-      width: 100% / $grid-columns * $i;
-    }
-    .rev-Col--mediumOffset#{$i} {
-      left: 100% / $grid-columns * $i;
-    }
-    .rev-Col--mediumPush#{$i} {
-      @include rev-Col-push($i);
-    }
-    .rev-Col--mediumPull#{$i} {
-      @include rev-Col-pull($i);
-    }
-  }
-  .rev-Col--mediumCentered {
-    float: none;
-    margin-left: auto;
-    margin-right: auto;
-  }
-  .rev-Col--mediumUncentered {
-    float: left;
-  }
-}
-@include breakpoint(large)  {
-  @for $i from 1 through $grid-columns {
-    .rev-Col--large#{$i} {
-      width: 100% / $grid-columns * $i;
-    }
-    .rev-Col--largeOffset#{$i} {
-      left: 100% / $grid-columns * $i;
-    }
-    .rev-Col--largePush#{$i} {
-      @include rev-Col-push($i);
-    }
-    .rev-Col--largePull#{$i} {
-      @include rev-Col-pull($i);
-    }
-  }
-  .rev-Col--largeCentered {
-    float: none;
-    margin-left: auto;
-    margin-right: auto;
-  }
-  .rev-Col--largeUncentered {
-    float: left;
-  }
-}
-@include breakpoint(xlarge) {
-  @for $i from 1 through $grid-columns {
-    .rev-Col--xlarge#{$i} {
-      width: 100% / $grid-columns * $i;
-    }
-    .rev-Col--xlargeOffset#{$i} {
-      left: 100% / $grid-columns * $i;
-    }
-    .rev-Col--xlargePush#{$i} {
-      @include rev-Col-push($i);
-    }
-    .rev-Col--xlargePull#{$i} {
-      @include rev-Col-pull($i);
-    }
-  }
-  .rev-Col--xlargeCentered {
-    float: none;
-    margin-left: auto;
-    margin-right: auto;
-  }
-  .rev-Col--xlargeUncentered {
-    float: left;
-  }
-}
-@include breakpoint(xxlarge)  {
-  @for $i from 1 through $grid-columns {
-    .rev-Col--xxlarge#{$i} {
-      width: 100% / $grid-columns * $i;
-    }
-    .rev-Col--xxlargeOffset#{$i} {
-      left: 100% / $grid-columns * $i;
-    }
-    .rev-Col--xxlargePush#{$i} {
-      @include rev-Col-push($i);
-    }
-    .rev-Col--xxlargePull#{$i} {
-      @include rev-Col-pull($i);
-    }
-  }
-  .rev-Col--xxlargeCentered {
-    float: none;
-    margin-left: auto;
-    margin-right: auto;
-  }
-  .rev-Col--xxlargeUncentered {
-    float: left;
   }
 }

--- a/scss/components/_components.scss
+++ b/scss/components/_components.scss
@@ -1,7 +1,9 @@
 //GRIDS
 @import 'Grid';
 @import 'BlockGrid';
-@import 'FlexGrid';
+@import 'FlexRows';
+@import 'FlexCols';
+@import 'FloatCols';
 @import 'Expander';
 
 // LAYOUT ELEMENTS

--- a/scss/mixins/_flex.scss
+++ b/scss/mixins/_flex.scss
@@ -19,6 +19,9 @@
     flex: 1;
   }
 }
+@mixin flexDirectionCol {
+  @include flexProps($flex-direction: column);
+}
 @mixin flexJustifyStart {
   @include flexProps($wrap: wrap);
 }

--- a/src/Col.js
+++ b/src/Col.js
@@ -3,61 +3,77 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 const BOOL_PROPS_TO_CLASS_NAMES = {
-  smallCentered: ['small-centered', 'rev-Col--smallCentered'],
-  mediumCentered: ['medium-centered', 'rev-Col--mediumCentered'],
-  largeCentered: ['large-centered', 'rev-Col--largeCentered'],
+  // props for float grid
+  smallCentered: ['rev-Col--smallCentered'],
+  mediumCentered: ['rev-Col--mediumCentered'],
+  largeCentered: ['rev-Col--largeCentered'],
+  xlargeCentered: ['rev-Col--xlargeCentered'],
+  xxlargeCentered: ['rev-Col--xxlargeCentered'],
 
-  smallUncentered: ['small-uncentered', 'rev-Col--smallUncentered'],
-  mediumUncentered: ['medium-uncentered', 'rev-Col--mediumUncentered'],
-  largeUncentered: ['large-uncentered', 'rev-Col--largeUncentered'],
+  smallUncentered: ['rev-Col--smallUncentered'],
+  mediumUncentered: ['rev-Col--mediumUncentered'],
+  largeUncentered: ['rev-Col--largeUncentered'],
+  xlargeUncentered: ['rev-Col--xlargeUncentered'],
+  xxlargeUncentered: ['rev-Col--xxlargeUncentered'],
 
-  mediumExpand: ['medium-expand', 'rev-Col--mediumExpand'],
-  largeExpand: ['large-expand', 'rev-Col--largeExpand'],
+  end: ['rev-Col--end'],
 
-  end: ['end', 'rev-Col--end'],
+  // padding props for float or flex grid
+  collapse: ['rev-Col--collapse'],
+  mediumCollapse: ['rev-Col--mediumCollapse'],
+  largeCollapse: ['rev-Col--largeCollapse'],
+  xlargeCollapse: ['rev-Col--xlargeCollapse'],
+  xxlargeCollapse: ['rev-Col--xxlargeCollapse'],
 
-  expanded: ['expanded', 'rev-Col--expanded'],
+  uncollapse: ['rev-Col--uncollapse'],
+  mediumUncollapse: ['rev-Col--mediumUncollapse'],
+  largeUncollapse: ['rev-Col--largeUncollapse'],
+  xlargeUncollapse: ['rev-Col--xlargeUncollapse'],
+  xxlargeUncollapse: ['rev-Col--xxlargeUncollapse'],
 
-  shrink: ['shrink', 'rev-Col--shrink'],
+  // width props for flex grid
+  shrink: ['rev-Col--shrink'],
 
-  left: ['align-self-left', 'rev-Col--left'],
-  right: ['align-self-right', 'rev-Col--right'],
-  center: ['align-self-center', 'rev-Col--center'],
-  justify: ['align-self-justify', 'rev-Col--justify'],
-  spaced: ['align-self-spaced', 'rev-Col--spaced'],
-  top: ['align-self-top', 'rev-Col--top'],
-  middle: ['align-self-middle', 'rev-Col--middle'],
-  bottom: ['align-self-bottom', 'rev-Col--bottom'],
-  stretch: ['align-self-stretch', 'rev-Col--stretch'],
+  // align-self props for flex grid
+  alignStart: ['rev-Col--alignStart'],
+  alignEnd: ['rev-Col--alignEnd'],
+  alignCenter: ['rev-Col--alignCenter'],
+  alignBaseline: ['rev-Col--alignBaseline'],
+  alignStretch: ['rev-Col--alignStretch'],
 }
 
 const BOOL_PROPS = Object.keys(BOOL_PROPS_TO_CLASS_NAMES)
 
 const NUMBER_PROPS_TO_CLASS_NAMES = {
-  small: (arg) => [`small-${arg}`, `rev-Col--small${arg}`],
-  medium: (arg) => [`medium-${arg}`, `rev-Col--medium${arg}`],
-  large: (arg) => [`large-${arg}`, `rev-Col--large${arg}`],
-  xlarge: (arg) => [`xlarge-${arg}`, `rev-Col--xlarge${arg}`],
-  xxlarge: (arg) => [`xxlarge-${arg}`, `rev-Col--xxlarge${arg}`],
+  small: (arg) => [`rev-Col--small${arg}`],
+  medium: (arg) => [`rev-Col--medium${arg}`],
+  large: (arg) => [`rev-Col--large${arg}`],
+  xlarge: (arg) => [`rev-Col--xlarge${arg}`],
+  xxlarge: (arg) => [`rev-Col--xxlarge${arg}`],
 
-  smallOffset: (arg) => [`small-offset-${arg}`, `rev-Col--smallOffset${arg}`],
-  mediumOffset: (arg) => [
-    `medium-offset-${arg}`,
-    `rev-Col--mediumOffset${arg}`,
-  ],
-  largeOffset: (arg) => [`large-offset-${arg}`, `rev-Col--largeOffset${arg}`],
+  smallOffset: (arg) => [`rev-Col--smallOffset${arg}`],
+  mediumOffset: (arg) => [`rev-Col--mediumOffset${arg}`,],
+  largeOffset: (arg) => [`rev-Col--largeOffset${arg}`],
+  xlargeOffset: (arg) => [`rev-Col--xlargeOffset${arg}`],
+  xxlargeOffset: (arg) => [`rev-Col--xxlargeOffset${arg}`],
 
-  smallPush: (arg) => [`small-push-${arg}`, `rev-Col--smallPush${arg}`],
-  mediumPush: (arg) => [`medium-push-${arg}`, `rev-Col--mediumPush${arg}`],
-  largePush: (arg) => [`large-push-${arg}`, `rev-Col--largePush${arg}`],
+  smallPush: (arg) => [`rev-Col--smallPush${arg}`],
+  mediumPush: (arg) => [`rev-Col--mediumPush${arg}`],
+  largePush: (arg) => [`rev-Col--largePush${arg}`],
+  xlargePush: (arg) => [`rev-Col--xlargePush${arg}`],
+  xxlargePush: (arg) => [`rev-Col--xxlargePush${arg}`],
 
-  smallPull: (arg) => [`small-pull-${arg}`, `rev-Col--smallPull${arg}`],
-  mediumPull: (arg) => [`medium-pull-${arg}`, `rev-Col--mediumPull${arg}`],
-  largePull: (arg) => [`large-pull-${arg}`, `rev-Col--largePull${arg}`],
+  smallPull: (arg) => [`rev-Col--smallPull${arg}`],
+  mediumPull: (arg) => [`rev-Col--mediumPull${arg}`],
+  largePull: (arg) => [`rev-Col--largePull${arg}`],
+  xlargePull: (arg) => [`rev-Col--xlargePull${arg}`],
+  xxlargePull: (arg) => [`rev-Col--xxlargePull${arg}`],
 
-  smallOrder: (arg) => [`small-order-${arg}`, `rev-Col--smallOrder${arg}`],
-  mediumOrder: (arg) => [`medium-order-${arg}`, `rev-Col--mediumOrder${arg}`],
-  largeOrder: (arg) => [`large-order-${arg}`, `rev-Col--largeOrder${arg}`],
+  smallOrder: (arg) => [`rev-Col--smallOrder${arg}`],
+  mediumOrder: (arg) => [`rev-Col--mediumOrder${arg}`],
+  largeOrder: (arg) => [`rev-Col--largeOrder${arg}`],
+  xlargeOrder: (arg) => [`rev-Col--xlargeOrder${arg}`],
+  xxlargeOrder: (arg) => [`rev-Col--xxlargeOrder${arg}`],
 }
 
 const NUMBER_PROPS = Object.keys(NUMBER_PROPS_TO_CLASS_NAMES)
@@ -94,7 +110,6 @@ export default class Col extends Component {
 
     const divClassName = classNames(
       className,
-      'columns',
       'rev-Col',
       boolClassNames,
       numberClassNames

--- a/src/Col.js
+++ b/src/Col.js
@@ -102,7 +102,7 @@ export default class Col extends Component {
       const value = props[name]
       const func = NUMBER_PROPS_TO_CLASS_NAMES[name]
 
-      if (value !== null) {
+      if (value != null) {
         numberClassNames.push(func(value))
       }
       delete props[name]

--- a/src/Col.test.js
+++ b/src/Col.test.js
@@ -8,7 +8,7 @@ describe('Col', () => {
   })
 
   it('should add className to child', () => {
-    const inherentClassName = 'columns'
+    const inherentClassName = 'rev-Col'
     const testClassName = '__TEST__'
 
     const childClassName = shallow(<Col className={testClassName} />)
@@ -21,21 +21,21 @@ describe('Col', () => {
 
   it('handles column number props', () => {
     const propToClass = {
-      small: 'small',
-      medium: 'medium',
-      large: 'large',
-      smallOffset: 'small-offset',
-      mediumOffset: 'medium-offset',
-      largeOffset: 'large-offset',
-      smallPush: 'small-push',
-      mediumPush: 'medium-push',
-      largePush: 'large-push',
-      smallPull: 'small-pull',
-      mediumPull: 'medium-pull',
-      largePull: 'large-pull',
-      smallOrder: 'small-order',
-      mediumOrder: 'medium-order',
-      largeOrder: 'large-order',
+      small: 'rev-Col--small',
+      medium: 'rev-Col--medium',
+      large: 'rev-Col--large',
+      smallOffset: 'rev-Col--smallOffset',
+      mediumOffset: ' rev-Col--mediumOffset',
+      largeOffset: 'rev-Col--largeOffset',
+      smallPush: 'rev-Col--smallPush',
+      mediumPush: 'rev-Col--mediumPush',
+      largePush: 'rev-Col--largePush',
+      smallPull: 'rev-Col--smallPull',
+      mediumPull: 'rev-Col--mediumPull',
+      largePull: 'rev-Col--largePull',
+      smallOrder: 'rev-Col--smallOrder',
+      mediumOrder: 'rev-Col--mediumOrder',
+      largeOrder: 'rev-Col--largeOrder',
     }
 
     for (const key in propToClass) {
@@ -52,6 +52,6 @@ describe('Col', () => {
   it('handles boolean props', () => {
     const col = shallow(<Col smallCentered />)
 
-    expect(col.prop('className')).to.contain('small-centered')
+    expect(col.prop('className')).to.contain('rev-Col--smallCentered')
   })
 })

--- a/src/Row.js
+++ b/src/Row.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 const BOOL_PROPS_TO_CLASS_NAMES = {
+  // zeros out padding on direct child cols
   collapse: ['rev-Row--collapse'],
   smallCollapse: ['rev-Row--smallCollapse'],
   mediumCollapse: ['rev-Row--mediumCollapse'],
@@ -10,6 +11,7 @@ const BOOL_PROPS_TO_CLASS_NAMES = {
   xlargeCollapse: ['rev-Row--xlargeCollapse'],
   xxlargeCollapse: ['rev-Row--xxlargeCollapse'],
 
+  // resets padding on direct child cols
   uncollapse: ['rev-Row--uncollapse'],
   smallUncollapse: ['rev-Row--smallUncollapse'],
   mediumUncollapse: ['rev-Row--mediumUncollapse'],
@@ -31,20 +33,20 @@ const BOOL_PROPS_TO_CLASS_NAMES = {
   xlargeUnflex: ['rev-Row--xlargeUnflex'],
   xxlargeUnflex: ['rev-Row--xxlargeUnflex'],
 
-  smallUnstack: ['rev-Row--smallUnstack'],
-  mediumUnstack: ['rev-Row--mediumUnstack'],
-  largeUnstack: ['rev-Row--largeUnstack'],
-  xlargeUnstack: ['rev-Row--xlargeUnstack'],
-  xxlargeUnstack: ['rev-Row--xxlargeUnstack'],
+  // flex grid props affecting child cols
+  directionCol: ['rev-Row--directionCol'],
 
-  right: ['rev-Row--right'],
-  center: ['rev-Row--center'],
-  justify: ['rev-Row--justify'],
-  spaced: ['rev-Row--spaced'],
-  top: ['rev-Row--top'],
-  middle: ['rev-Row--middle'],
-  bottom: ['rev-Row--bottom'],
-  stretch: ['rev-Row--stretch'],
+  justifyStart: ['rev-Row--justifyStart'],
+  justifyEnd: ['rev-Row--justifyEnd'],
+  justifyCenter: ['rev-Row--justifyCenter'],
+  justifySpaceAround: ['rev-Row--justifySpaceAround'],
+  justifySpaceBetween: ['rev-Row--justifySpaceBetween'],
+
+  alignStart: ['rev-Row--alignStart'],
+  alignEnd: ['rev-Row--alignEnd'],
+  alignCenter: ['rev-Row--alignCenter'],
+  alignBaseline: ['rev-Row--alignBaseline'],
+  alignStretch: ['rev-Row--alignStretch'],
 }
 
 const BOOL_PROPS = Object.keys(BOOL_PROPS_TO_CLASS_NAMES)


### PR DESCRIPTION
connects to #217  updates to row and col components

- renamed props so that they more closely match the css properties they represent
- reorganized the row and col and grid css
- removed old foundation classNames (no longer needed)
- removed unused props
- added css for all flex props (some props didn't have css to go along with them)
- fixed the docs src grid styling

<img width="1429" alt="screen shot 2018-05-01 at 12 11 10 pm" src="https://user-images.githubusercontent.com/3287583/39483681-c4829db0-4d38-11e8-93ad-67c46e752638.png">

**TODO:** @prehnRA 
- row and col components are getting all of the number prop classNames added regardless of the presence of that prop on the component

I'm pretty sure that this is the offending bit of code:
```
NUMBER_PROPS.forEach((name) => {
      const value = props[name]
      const func = NUMBER_PROPS_TO_CLASS_NAMES[name]

      if (value !== null) {
        numberClassNames.push(func(value))
      }
      delete props[name]
    })
```