### PR TITLE
#218 Datepicker not working in IE11

### DIFF
--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -20,9 +20,8 @@ function goodDateInput() {
   } else {
     const element = document.createElement('input')
 
-    element.type = 'date'
-    element.value = '!)'
-    return element.value === ''
+    element.setAttribute('type', 'date')
+    return element.type === 'date'
   }
 }
 


### PR DESCRIPTION
#218 
Getting invalid argument errors on IE11

IE11 throws an error "invalid arguments" when setting an input's type property (not attribute) to a value that it does not support (e.g. date).
In goodDateInput function I replaced element.type="date" by element.setAttribute('type', 'date')
![date-picker](https://user-images.githubusercontent.com/15636958/39667575-4fdba200-507f-11e8-833e-76dc0bd29489.PNG)
